### PR TITLE
typo: replace mAAS* when DAAS*

### DIFF
--- a/config.env
+++ b/config.env
@@ -10,7 +10,7 @@ DAAS_API_ADDRESS=:8443
 # String: IP Address
 DAAS_API_CERT="server.crt"
 # String: IP Address
-mAAS_API_KEY="server.key"
+DAAS_API_KEY="server.key"
 # String: "redis" or "sqlite"
 # DAAS_API_BACKEND=sqlite
 


### PR DESCRIPTION
env var `mAAS_API_KEY` does not exist but `DAAS_API_KEY` does